### PR TITLE
feat: add active link to navigation

### DIFF
--- a/src/components/MainNav/MainNav.spec.tsx
+++ b/src/components/MainNav/MainNav.spec.tsx
@@ -2,11 +2,16 @@ import { NavItem } from '@/types';
 import { fireEvent, render, screen } from '@testing-library/react';
 
 import { MainNav } from './MainNav';
-
 const mockItems: NavItem[] = [
   { title: 'Item 1', href: '/item1' },
   { title: 'Item 2', href: '/item2' }
 ];
+
+jest.mock('next/navigation', () => ({
+  usePathname() {
+    return mockItems[0].href;
+  }
+}));
 
 describe('MainNav', () => {
   it('should render title', () => {
@@ -62,5 +67,16 @@ describe('MainNav', () => {
 
     const itemsAfterClick = screen.queryAllByText('Item 1');
     expect(itemsAfterClick).toHaveLength(1);
+  });
+
+  it('should highlight active item', () => {
+    render(<MainNav items={mockItems} />);
+    const activeItem = screen.getByText('Item 1');
+    expect(activeItem).toHaveClass('text-link');
+    expect(activeItem).toHaveAttribute('aria-current', 'page');
+
+    const inactiveItem = screen.getByText('Item 2');
+    expect(inactiveItem).not.toHaveClass('text-link');
+    expect(inactiveItem).not.toHaveAttribute('aria-current');
   });
 });

--- a/src/components/MainNav/MainNav.tsx
+++ b/src/components/MainNav/MainNav.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 
 import { NavItem } from '@/types';
 
@@ -14,6 +15,7 @@ type MainNavProps = {
 
 export const MainNav = ({ items }: MainNavProps) => {
   const { isOpenMenu, handleToggleMenu } = useMainNav();
+  const pathname = usePathname();
 
   return (
     <>
@@ -23,7 +25,13 @@ export const MainNav = ({ items }: MainNavProps) => {
         <S.List>
           {items.map((item) => (
             <S.NavItem key={item.title}>
-              <Link href={item.href}>{item.title} </Link>
+              <Link
+                className={pathname === item.href ? 'text-link' : ''}
+                aria-current={pathname === item.href ? 'page' : undefined}
+                href={item.href}
+              >
+                {item.title}{' '}
+              </Link>
             </S.NavItem>
           ))}
         </S.List>


### PR DESCRIPTION
This pull request primarily focuses on enhancing the navigation feature in the `MainNav` component. The changes include the addition of a mock router for testing, a new test case for the active item highlighting, and modifications in the `MainNav` component to highlight the active navigation item.

Testing improvements:

* [`src/components/MainNav/MainNav.spec.tsx`](diffhunk://#diff-e69ae5cef6f2144e45166e9ca8d2c9353c9d16b94cf16a499366fe18b7d82c1fR11-R21): Introduced a mock router to simulate the behavior of the `next/router` during testing. This allows the test cases to have control over the current route, which is necessary for testing the active item highlighting feature.
* [`src/components/MainNav/MainNav.spec.tsx`](diffhunk://#diff-e69ae5cef6f2144e45166e9ca8d2c9353c9d16b94cf16a499366fe18b7d82c1fR77-R87): Added a new test case to verify that the active navigation item is highlighted correctly. This test checks if the active item has the appropriate CSS class and `aria-current` attribute, and if the inactive item does not have these.

Navigation feature enhancements:

* [`src/components/MainNav/MainNav.tsx`](diffhunk://#diff-1bd8d39251beb9380dd70c0f92b2eabbc6a245eb14098528c19b9545879b58e5R4): Imported the `useRouter` hook from `next/router` to access the current route inside the `MainNav` component.
* [`src/components/MainNav/MainNav.tsx`](diffhunk://#diff-1bd8d39251beb9380dd70c0f92b2eabbc6a245eb14098528c19b9545879b58e5R18): Utilized the `useRouter` hook in the `MainNav` component to get the current route.
* [`src/components/MainNav/MainNav.tsx`](diffhunk://#diff-1bd8d39251beb9380dd70c0f92b2eabbc6a245eb14098528c19b9545879b58e5L26-R36): Modified the rendering of navigation items to add a `text-link` CSS class and `aria-current` attribute to the active item, based on the current route.